### PR TITLE
Fix model naming in spec generation

### DIFF
--- a/classify_cases.py
+++ b/classify_cases.py
@@ -304,7 +304,7 @@ def create_output_spec(modelname, dataoptions):
             (loaders.CountLoader.create_inferred, {"tube": 1}),
             (loaders.CountLoader.create_inferred, {"tube": 2}),
         ]
-    elif modelname == "sommap":
+    elif modelname == "som":
         partial_spec = [
             (loaders.Map2DLoader.create_inferred, {"tube": 1}),
             (loaders.Map2DLoader.create_inferred, {"tube": 2}),


### PR DESCRIPTION
The old model input name `sommap` is being deprecated for the simpler `som` name. This required renaming all string checks for model to `som`. This seems to have been missed here.