### PR TITLE
wrapping path objects to string

### DIFF
--- a/classify_cases.py
+++ b/classify_cases.py
@@ -208,7 +208,7 @@ def run_save_model(
     )
     pred_mat = model.predict_generator(testseq, workers=4, use_multiprocessing=True)
 
-    model.save(modelpath / f"model_{name}.h5")
+    model.save(str(modelpath / f"model_{name}.h5"))
     with open(str(modelpath / f"history_{name}.p"), "wb") as hfile:
         pickle.dump(history.history, hfile)
 
@@ -421,8 +421,8 @@ def create_stats(outpath, dataset, pred_df, confusion_sizes):
         title = f"Confusion matrix (weighted f1 {stats['weighted_f1']:.2f} unweighted f1 {stats['unweighted_f1']:.2f})"
         plotting.plot_confusion_matrix(
             conf.values, groupstat["groups"], normalize=True,
-            title=title, filename=outpath / f"confusion_{gname}", dendroname=None, sizes=sizes)
-        conf.to_csv(outpath / f"confusion_{gname}.csv")
+            title=title, filename=outpath / f"confusion_{gname}.png", dendroname=None, sizes=sizes)
+        utils.save_csv(conf, outpath / f"confusion_{gname}.csv")
         with open(str(outpath / f"stats_{gname}.json"), "w") as jsfile:
             json.dump(stats, jsfile)
 
@@ -526,6 +526,7 @@ def main():
     config.to_toml(outpath / "config.toml")
 
     dataset = load_dataset(**config["dataset"])
+
 
     # split into train and test set
     # TODO: enable more complicated designs with kfold etc

--- a/flowcat/visual/plotting.py
+++ b/flowcat/visual/plotting.py
@@ -178,7 +178,7 @@ def plot_confusion_matrix(
         axes.set_title(title)
         fig.tight_layout()
         FigureCanvas(fig)
-        fig.savefig(filename, dpi=300)
+        fig.savefig(str(filename), dpi=300)
 
     if dendroname is not None:
         fig = Figure()


### PR DESCRIPTION
ValueError: fname must be a PathLike or file handle

Fixing path objects in classify_cases and plotting.py